### PR TITLE
Improve get-docs sample

### DIFF
--- a/app/report/[id]/page.tsx
+++ b/app/report/[id]/page.tsx
@@ -1,0 +1,40 @@
+"use server";
+
+import Markdown from "react-markdown";
+
+import { documents } from "@/lib/db";
+import { withFGA } from "@/sdk/fga";
+import { withCheckPermission } from "@/sdk/fga/next/with-check-permission";
+
+async function Report({ params }: { params: { id: string } }) {
+  const document = await documents.getByID(params.id);
+  return (
+    <main
+      className="flex overflow-hidden h-full  mx-auto pt-4"
+      style={{ maxHeight: "calc(100vh - 56px)" }}
+    >
+      <div className="h-full w-full overflow-hidden rounded-md">
+        <div className="flex flex-col flex-no-wrap h-full overflow-y-auto overscroll-y-none">
+          <div className="flex-1 min-w-0 max-w-4xl mx-auto w-full"></div>
+          <div className="flex flex-col max-w-4xl mx-auto w-full mb-5">
+            <h2 className="text-2xl font-bold tracking-tight">
+              {document.metadata.title}
+            </h2>
+            <Markdown className="markdown">{document.content}</Markdown>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export default withCheckPermission(
+  {
+    checker: ({ params }) =>
+      withFGA({
+        object: `doc:${params.id}`,
+        relation: "can_view",
+      }),
+  },
+  Report
+);

--- a/database/market0/V010__remove_link_from_docs.sql
+++ b/database/market0/V010__remove_link_from_docs.sql
@@ -1,0 +1,5 @@
+UPDATE
+  documents
+SET
+  metadata = metadata - 'link';
+

--- a/lib/db/documents.ts
+++ b/lib/db/documents.ts
@@ -1,3 +1,5 @@
+import { getUser } from "@/sdk/fga";
+
 import { sql } from "./sql";
 
 type Document = {
@@ -31,4 +33,13 @@ export const query = async (type?: 'earning' | 'forecast', symbol?: string): Pro
       AND metadata->>'symbol' = ${symbol ?? null} OR ${symbol == null}
   `;
   return res;
+};
+
+export const getByID = async (id: string): Promise<Document> => {
+  const res = await sql<Document[]>`
+    SELECT *
+    FROM documents
+    WHERE metadata->>'id' = ${id}
+  `;
+  return res[0];
 };

--- a/llm/components/documents.tsx
+++ b/llm/components/documents.tsx
@@ -54,7 +54,7 @@ export const Documents = ({
                 className="font-normal pl-3"
               >
                 <Link
-                  href={document.metadata.link}
+                  href={document.metadata.link ?? `/report/${document.metadata.id}`}
                   target="_black"
                   rel="noopener noreferrer"
                   className="cursor-pointer flex items-center gap-4 py-2 px-3 pr-1 justify-between"

--- a/llm/tools/add-conditional-purchase.tsx
+++ b/llm/tools/add-conditional-purchase.tsx
@@ -13,7 +13,7 @@ import {
   requireGuardianEnrollment,
 } from "@/sdk/auth0/mgmt";
 import { getUser, withFGA } from "@/sdk/fga";
-import { withCheckPermission } from "@/sdk/fga/vercel-ai/with-check-permisssion";
+import { withCheckPermission } from "@/sdk/fga/vercel-ai/with-check-permission";
 
 type ToolParams = {
   symbol: string;

--- a/llm/tools/show-stock-purchase-ui.tsx
+++ b/llm/tools/show-stock-purchase-ui.tsx
@@ -4,7 +4,7 @@ import { RELATION } from "@/lib/constants";
 import { getStockPrices } from "@/lib/market/stocks";
 import * as serialization from "@/llm/components/serialization";
 import { withFGA } from "@/sdk/fga";
-import { withCheckPermission } from "@/sdk/fga/vercel-ai/with-check-permisssion";
+import { withCheckPermission } from "@/sdk/fga/vercel-ai/with-check-permission";
 
 import { defineTool } from "../ai-helpers";
 import { StockPurchase } from "../components/stock-purchase";

--- a/sdk/fga/index.ts
+++ b/sdk/fga/index.ts
@@ -80,5 +80,3 @@ export async function withFGA(params: withFGAParams) {
 
   return await checkPermission(checkPermissionsParams);
 }
-
-export const checkAuthorization = withFGA;

--- a/sdk/fga/next/with-check-permission.tsx
+++ b/sdk/fga/next/with-check-permission.tsx
@@ -1,0 +1,49 @@
+type WithCheckPermissionParams<PageParams> = {
+  checker: (toolParams: PageParams) => Promise<boolean>;
+  onUnauthorized?: (toolParam: PageParams) => Promise<JSX.Element>;
+};
+
+const DEFAULT_UNAUTHORIZED_MESSAGE =
+  "You are not authorized to perform this action.";
+
+async function defaultOnUnauthorized() {
+  return <div>${DEFAULT_UNAUTHORIZED_MESSAGE}</div>;
+}
+
+/**
+ * Wrap a Serverless page with an FGA permission check.
+ * @param params
+ * @param params.checker - A function that receives the same parameter
+ *     than the serverless function and checks
+ *     if the user has permission to access the page.
+ *     This can be `withFGA`.
+ * @param params.onUnauthorized - A function that receives the same parameter
+ *     than the serverless function and returns a JSX element.
+ *     This can be used to customize the unauthorized message.
+ * @param fn - The serverless function to wrap.
+ * @returns A new serverless function that checks permissions before executing the original function.
+ */
+export function withCheckPermission<PageParams = any>(
+  params: WithCheckPermissionParams<PageParams>,
+  fn: (toolParam: PageParams) => Promise<JSX.Element>
+) {
+  return async function (toolParam: PageParams): Promise<JSX.Element> {
+    let allowed = false;
+
+    try {
+      allowed = await params.checker(toolParam);
+    } catch (e) {
+      console.error(e);
+    }
+
+    if (allowed) {
+      return fn(toolParam);
+    } else {
+      if (params.onUnauthorized) {
+        return params.onUnauthorized(toolParam);
+      }
+
+      return defaultOnUnauthorized();
+    }
+  };
+}

--- a/sdk/fga/vercel-ai/with-check-permission.tsx
+++ b/sdk/fga/vercel-ai/with-check-permission.tsx
@@ -23,6 +23,20 @@ async function* defaultOnUnauthorized(): AsyncGenerator<
   return DEFAULT_UNAUTHORIZED_MESSAGE;
 }
 
+/**
+ * Wrap the generate function of a vercel/ai tool with an FGA permission check.
+ *
+ * @param params
+ * @param params.checker - A function that receives the same parameter
+ *     than the generate func and checks
+ *     if the user has permission to the tool.
+ *     This can be `withFGA`.
+ * @param params.onUnauthorized - A function that receives the same parameter
+ *     than the generate func and returns a UI generator.
+ *     This can be used to customize the unauthorized message.
+ * @param fn - The generate func to wrap.
+ * @returns A new generate func that checks permissions before executing the original function.
+ */
 export function withCheckPermission<ToolParam = any>(
   params: WithCheckPermissionParams<ToolParam>,
   fn: (toolParam: ToolParam) => AsyncGenerator<ReactNode, ReactNode, unknown>


### PR DESCRIPTION
Improve the get documents example by making it clearer when it shows forecasts versus earnings.

I also fixed the link to the reference doc.