### PR TITLE
Fixes related to the purchase ui

### DIFF
--- a/llm/components/purchase-confirmation.tsx
+++ b/llm/components/purchase-confirmation.tsx
@@ -1,23 +1,27 @@
-import { CheckGreenIcon, StockDownIcon, StockUpIcon } from "@/components/icons";
+import { CancelRedIcon, CheckGreenIcon, StockDownIcon, StockUpIcon } from "@/components/icons";
 
 import WarningWrapper from "./warning-wrapper";
 
 export const PurchaseConfirmation = ({
-  amount,
+  quantity,
   price,
   symbol,
   market,
   currency,
   company,
   delta,
+  message,
+  success
 }: {
-  amount: number;
+  quantity: number;
   price: number;
   symbol: string;
   market: string;
   currency: string;
   company: string;
   delta: number;
+  message: string;
+  success: boolean;
 }) => {
   return (
     <WarningWrapper className="max-w-xl">
@@ -52,9 +56,9 @@ export const PurchaseConfirmation = ({
         </div>
 
         <div className="flex flex-row gap-4 pb-2 mt-5 mx-3 border-t border-white/20 pt-5 items-center">
-          <CheckGreenIcon />
+          { success ? <CheckGreenIcon /> : <CancelRedIcon />}
           <div className="text-white text-lg font-light">
-            You have successfully purchased {amount} ${symbol}.
+            {message}
           </div>
         </div>
       </div>

--- a/llm/tools/show-stock-purchase-ui.tsx
+++ b/llm/tools/show-stock-purchase-ui.tsx
@@ -1,3 +1,4 @@
+import { generateId } from "ai";
 import { z } from "zod";
 
 import { RELATION } from "@/lib/constants";
@@ -84,30 +85,30 @@ export default defineTool("show_stock_purchase_ui", () => {
         const stockStatus = await getStockPrices({ symbol });
         const price = limit ?? stockStatus.current_price;
 
+        const messageID = generateId();
+
+        const params = {
+          messageID,
+          symbol,
+          price,
+          market,
+          company,
+          currency,
+          initialQuantity: numberOfShares,
+          delta: stockStatus.delta,
+        };
+
         history.update({
+          id: messageID,
           role: "assistant",
           content: `Showing stock purchase UI for ${symbol} at ${price}`,
           componentName: serialization.names.get(StockPurchase)!,
-          params: {
-            symbol,
-            price,
-            market,
-            company,
-            currency,
-            numberOfShares,
-            delta: stockStatus.delta,
-          },
+          params,
         });
 
         return (
           <StockPurchase
-            symbol={symbol}
-            price={price}
-            delta={stockStatus.delta}
-            numberOfShares={numberOfShares}
-            market={market}
-            company={company}
-            currency={currency}
+            {...params}
           />
         );
       }

--- a/llm/types.ts
+++ b/llm/types.ts
@@ -5,6 +5,12 @@ import * as serialization from "@/llm/components/serialization";
 export { Document } from "@langchain/core/documents";
 
 export interface ServerMessage {
+  /**
+   * Optional id for the message.
+   * Make it easier to find the message in the UI and swap history.
+   */
+  id?: string;
+
   role: "user" | "assistant" | "system" | "tool";
   content: string | object;
 


### PR DESCRIPTION
1. The confirm-purchase action was not validatin if the user was authorized. This is a cross-cutting concern and should be validated before showing the UI, but also after in the server-side action.

2. The purchase UI component was stored in the chat history for ever. Even after confirming the purchase. This caused the UI to stick in the history and be shown again when the user reloaded the page.