### PR TITLE
Improve bot responses

### DIFF
--- a/llm/ai-helpers.ts
+++ b/llm/ai-helpers.ts
@@ -3,7 +3,7 @@ import { z, ZodTypeAny } from "zod";
 
 // Copied from vercel/ai because these types are not exported
 type Streamable$1 = ReactNode | Promise<ReactNode>;
-type Renderer$1<T extends Array<any>> = (...args: T) => Streamable$1 | Generator<Streamable$1, Streamable$1, void> | AsyncGenerator<Streamable$1, Streamable$1, void>;
+export type Renderer$1<T extends Array<any>> = (...args: T) => Streamable$1 | Generator<Streamable$1, Streamable$1, void> | AsyncGenerator<Streamable$1, Streamable$1, void>;
 export type RenderTool<T extends ZodTypeAny> = {
   description?: string;
   parameters: T,

--- a/llm/tools/set-employeer.tsx
+++ b/llm/tools/set-employeer.tsx
@@ -2,7 +2,6 @@ import { z } from "zod";
 
 import Loader from "@/components/loader";
 import { defineTool } from "@/llm/ai-helpers";
-import { getHistory } from "@/llm/utils";
 import { fgaClient, getUser } from "@/sdk/fga";
 
 import { withTextGeneration } from "../with-text-generation";

--- a/llm/tools/set-profile-attributes.tsx
+++ b/llm/tools/set-profile-attributes.tsx
@@ -27,7 +27,11 @@ export default defineTool("set_profile_attributes", async () => {
       const user = await getUser();
       await updateUser(user.sub, { givenName, familyName });
 
-      return `Noted that your name is ${givenName} ${familyName}.`;
+      return `
+        Your profile has been updated successfully.
+        ${givenName ? `Your first name is now ${givenName}.` : ""}
+        ${familyName ? `Your last name is now ${familyName}.` : ""}
+  `;
     }),
   };
 });

--- a/llm/tools/show-stock-purchase-ui.tsx
+++ b/llm/tools/show-stock-purchase-ui.tsx
@@ -10,6 +10,7 @@ import { withCheckPermission } from "@/sdk/fga/vercel-ai/with-check-permission";
 import { defineTool } from "../ai-helpers";
 import { StockPurchase } from "../components/stock-purchase";
 import { getHistory } from "../utils";
+import { withTextGeneration } from "../with-text-generation";
 
 type ToolParams = {
   symbol: string;
@@ -66,6 +67,16 @@ export default defineTool("show_stock_purchase_ui", () => {
             relation: RELATION.CAN_BUY_STOCKS,
             context: { current_time: new Date().toISOString() },
           }),
+        onUnauthorized: withTextGeneration(async function*({ symbol }) {
+          return `
+The user requesting the operation is not authorized to purchase ${symbol}.
+Specific restrictions might apply, such as:
+-  working for a financial institution
+-  working at ${symbol}.
+-  having a specific role in the company.
+Please tell the user they should contact the support desk of Market0 to get more information.
+`;
+        }),
       },
       async function* ({
         symbol,


### PR DESCRIPTION
It looks like a big commit but it is actually a refactoring of types and the use of `generateText` in the not authorized response. This replaces the canned response with a more friendly and contextualized response.

Example:

> I'm sorry, but it seems that you are not authorized to purchase shares of ATKO. Specific restrictions might apply, such as working for a financial institution or having a role within the company. I recommend contacting the support desk of Market for more information on this matter.
