### PR TITLE
improve forecast response on subscription

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -6,7 +6,7 @@ import { createAI, getAIState } from "ai/rsc";
 import { saveAIState } from "@/lib/db";
 import { confirmPurchase } from "@/llm/actions/confirm-purchase";
 import { continueConversation } from "@/llm/actions/continue-conversation";
-import { checkEnrollment, enrollToNewsletter } from "@/llm/actions/newsletter";
+import { checkEnrollment } from "@/llm/actions/newsletter";
 import { createGoogleTask } from "@/llm/actions/reminders";
 import * as serialization from "@/llm/components/serialization";
 import { ClientMessage, ServerMessage } from "@/llm/types";
@@ -27,7 +27,6 @@ export const AI = (p: Props) => {
       confirmPurchase,
       createGoogleTask,
       checkEnrollment,
-      enrollToNewsletter,
     },
     onSetAIState: async ({ state, done }) => {
       "use server";

--- a/llm/actions/continue-conversation.tsx
+++ b/llm/actions/continue-conversation.tsx
@@ -8,8 +8,8 @@ import { userUsage } from "@/lib/db";
 import { composeTools } from "@/llm/ai-helpers";
 import * as serialization from "@/llm/components/serialization";
 import { getSystemPrompt } from "@/llm/system-prompt";
-import getDocs from "@/llm/tools/get-docs";
 import getEvents from "@/llm/tools/get-events";
+import getForecasts from "@/llm/tools/get-forecasts";
 import listStocks from "@/llm/tools/list-stocks";
 import showCurrentPositions from "@/llm/tools/show-current-positions";
 import showStockPrice from "@/llm/tools/show-stock-price";
@@ -93,7 +93,7 @@ export async function continueConversation(
       showCurrentPositions,
       listStocks,
       getEvents,
-      getDocs,
+      getForecasts,
       setEmployeer,
       checkSubscription,
       setSubscription,

--- a/llm/actions/newsletter.ts
+++ b/llm/actions/newsletter.ts
@@ -3,6 +3,7 @@
 import { documents } from "@/lib/db";
 import { fgaClient, getUser } from "@/sdk/fga";
 import { Claims } from "@auth0/nextjs-auth0";
+import { ConsistencyPreference } from "@openfga/sdk";
 
 type Document = documents.Document;
 
@@ -59,6 +60,8 @@ export async function checkEnrollment({ symbol }: { symbol: string }) {
     user: `user:${user.sub}`,
     object: `doc:${docs[0].metadata.id}`,
     relation: "can_view",
+  }, {
+    consistency: ConsistencyPreference.HigherConsistency
   });
 
   return allowed;

--- a/llm/components/documents.tsx
+++ b/llm/components/documents.tsx
@@ -4,12 +4,7 @@ import { useActions, useUIState } from "ai/rsc";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ClientMessage, Document } from "@/llm/types";
 
 import { FormattedText } from "./FormattedText";
@@ -28,7 +23,7 @@ export const Documents = ({
 }) => {
   const [showEnrollment, setShowEnrollment] = useState(false);
 
-  const { checkEnrollment, enrollToNewsletter } = useActions();
+  const { checkEnrollment } = useActions();
   const { continueConversation } = useActions();
   const [, setMessages] = useUIState();
 
@@ -36,16 +31,13 @@ export const Documents = ({
     checkEnrollment({ symbol }).then((isEnrolled?: Boolean) => {
       setShowEnrollment(!isEnrolled);
     });
-    // TODO: verify this. checkEnrollment keeps changing.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [symbol]);
 
   const enroll = () => {
-    enrollToNewsletter();
     setShowEnrollment(false);
     (async () => {
       const response = await continueConversation({
-        message: `Thank me for subscribing to the newsletter and ask me if I would like to see the forecast for ${symbol} now.`,
+        message: `Subscribe me to the newsletter. Once done ASK me if I want to read the forecast analysis for ${symbol}.`,
         hidden: true,
       });
       setMessages((prevMessages: ClientMessage[]) => [

--- a/llm/tools/get-forecasts.tsx
+++ b/llm/tools/get-forecasts.tsx
@@ -13,22 +13,13 @@ import { getUser } from "@/sdk/fga";
 import stocks from "../../lib/market/stocks.json";
 import { aiParams } from "../ai-params";
 
-const buildRequiredInfoText = ({ earnings, forecasts}: { earnings: boolean, forecasts: boolean }) => {
-  const requiredInfo = [];
-  if (earnings) {
-    requiredInfo.push('earnings');
-  }
-  if (forecasts) {
-    requiredInfo.push('forecasts');
-  }
-  return requiredInfo.join(' and ');
-}
-
-export default defineTool("get_docs", () => {
+export default defineTool("get_forecasts", () => {
   const history = getHistory();
 
   return {
-    description: `Summarize earnings data and forecasts for a given stock.`,
+    description: `Summarize earnings data and forecasts for a given stock.
+If the user request a forecast analysis always run this.
+Do not use previously shared forecasts in the conversation.`,
     parameters: z.object({
       symbol: z
         .string()
@@ -48,7 +39,7 @@ export default defineTool("get_docs", () => {
         return `I'm sorry, I couldn't find any information for the stock ${symbol}.`;
       }
 
-      const { textStream, text: fullText, usage } = await streamText({
+      const { textStream, text: fullText } = await streamText({
         ...aiParams,
         temperature: 0.2,
         system: `

--- a/llm/tools/set-subscription.tsx
+++ b/llm/tools/set-subscription.tsx
@@ -23,10 +23,10 @@ export default defineTool("set_subscription", async () => {
           return 'You are already subscribed to newsletter.';
         }
         await enrollToNewsletter();
-        return `You have successfully subscribed to newsletter.
-          As part of this subscription you get access to analyst forecasts.
-          Would you like to get some forecast analysis?
-        `;
+        return `The user has successfully subscribed to the newsletter.
+        Be sure to thank them for subscribing.
+        Optionally, offer them a forecast analysis.
+      `;
       } else {
         if (!isUserEnrolled) {
           return 'You are not subscribed to newsletter.';

--- a/sdk/fga/langchain/rag.ts
+++ b/sdk/fga/langchain/rag.ts
@@ -1,6 +1,6 @@
 import { Document, DocumentInterface } from "@langchain/core/documents";
 import { BaseRetriever, BaseRetrieverInput } from "@langchain/core/retrievers";
-import { ClientCheckRequest, OpenFgaClient } from "@openfga/sdk";
+import { ClientCheckRequest, ConsistencyPreference, OpenFgaClient } from "@openfga/sdk";
 
 import type { CallbackManagerForRetrieverRun } from "@langchain/core/callbacks/manager";
 type FGARetrieverArgsWithoutCheckFromDocument<T extends CheckRequest> = {
@@ -56,7 +56,9 @@ export class FGARetriever<T extends CheckRequest> extends BaseRetriever {
     const accessByDocument = async function accessByDocument(
       checks: ClientCheckRequest[]
     ): Promise<Map<string, boolean>> {
-      const results = await fgaClient.batchCheck(checks);
+      const results = await fgaClient.batchCheck(checks, {
+        consistency: ConsistencyPreference.HigherConsistency
+      });
       return results.responses.reduce((c: Map<string, boolean>, v) => {
         c.set(v._request.object, v.allowed || false);
         return c;


### PR DESCRIPTION
Prevent the bot from executing another time the get-forecast tool when subscribing from the generated ui.