### PR TITLE
fix chat reader provisioning

### DIFF
--- a/app/chat/[id]/layout.tsx
+++ b/app/chat/[id]/layout.tsx
@@ -1,5 +1,3 @@
-import { redirect } from "next/navigation";
-
 import { AI } from "@/app/actions";
 import { ChatProvider } from "@/components/chat/context";
 import { Header } from "@/components/chat/header";
@@ -7,8 +5,8 @@ import { ShareConversation } from "@/components/chat/share";
 import { ChatUsersPermissionsList } from "@/components/chat/share/users-permissions-list";
 import { UnauthorizedError } from "@/components/fga/unauthorized";
 import { getHistoryFromStore } from "@/llm/actions/history";
-import { getUser, withFGA } from "@/sdk/fga";
-import { assignChatReader, isChatOwner, isChatUser } from "@/sdk/fga/chats";
+import { withFGA } from "@/sdk/fga";
+import { assignChatReader, isChatOwner, isUserInvitedToChat } from "@/sdk/fga/chats";
 import { withCheckPermission } from "@/sdk/fga/next/with-check-permission";
 
 type RootChatParams = Readonly<{
@@ -20,8 +18,7 @@ type RootChatParams = Readonly<{
 
 async function RootLayout({ children, params }: RootChatParams) {
   const conversation = await getHistoryFromStore(params.id);
-  const user = await getUser();
-  const { messages, ownerID } = conversation;
+  const { messages } = conversation;
   const isOwner = await isChatOwner(params.id);
 
   return (
@@ -48,30 +45,28 @@ async function RootLayout({ children, params }: RootChatParams) {
 
 export default withCheckPermission(
   {
-    checker: async ({ params }: RootChatParams) =>
-      withFGA({
-        object: `chat:${params.id}`,
-        relation: "can_view",
-      }),
-    onUnauthorized: async ({ params }: RootChatParams) => {
+    checker: async ({ params }: RootChatParams) => {
       const chatId = params.id;
+      const allowed = await withFGA({
+        object: `chat:${chatId}`,
+        relation: "can_view",
+      });
 
-      if (await isChatUser(chatId)) {
+      if (!allowed && (await isUserInvitedToChat(chatId))) {
         await assignChatReader(chatId);
-        return redirect(`/chat/${chatId}`);
+        return true;
       }
 
-      return (
-        <ChatProvider chatId={chatId} readOnly={true}>
-          <div className="flex flex-col h-full w-full">
-            <Header />
-            <UnauthorizedError>
-              The conversation does not exist or you are not authorized to access it.
-            </UnauthorizedError>
-          </div>
-        </ChatProvider>
-      );
+      return allowed;
     },
+    onUnauthorized: ({ params }: RootChatParams) => (
+      <ChatProvider chatId={params.id} readOnly={true}>
+        <div className="flex flex-col h-full w-full">
+          <Header />
+          <UnauthorizedError>The conversation does not exist or you are not authorized to access it.</UnauthorizedError>
+        </div>
+      </ChatProvider>
+    ),
   },
   RootLayout
 );

--- a/sdk/fga/chats.ts
+++ b/sdk/fga/chats.ts
@@ -45,7 +45,7 @@ export async function removeChatUser(id: string) {
   }
 }
 
-export async function isChatUser(chatId: string) {
+export async function isUserInvitedToChat(chatId: string) {
   const user = await getUser();
   const chatUser = await chatUsers.getByUserEmail(chatId, user.email);
   return !!chatUser;


### PR DESCRIPTION
This pull request includes changes to the `app/chat/[id]/layout.tsx` and `sdk/fga/chats.ts` files to improve permission handling and simplify the code. The most important changes include replacing the `isChatUser` function with `isUserInvitedToChat`, removing unnecessary user fetching, and modifying the `withCheckPermission` logic.

### Permission Handling Improvements:

* `app/chat/[id]/layout.tsx`: Replaced `isChatUser` with `isUserInvitedToChat` to check if a user is invited to a chat. ([app/chat/[id]/layout.tsxL1-R9](diffhunk://#diff-d89d93bab6f3c4bde199788a425f5f20a1fad667ddac10f6119fb0a1cb7bf211L1-R9), [app/chat/[id]/layout.tsxL51-R69](diffhunk://#diff-d89d93bab6f3c4bde199788a425f5f20a1fad667ddac10f6119fb0a1cb7bf211L51-R69))
* [`sdk/fga/chats.ts`](diffhunk://#diff-5639bf489b7809a436e1a93bcbd287e7ab21055ec155f99ede9c1b8ca5d3f881L48-R48): Renamed the `isChatUser` function to `isUserInvitedToChat` for better clarity.

### Code Simplification:

* `app/chat/[id]/layout.tsx`: Removed unnecessary user fetching and `ownerID` extraction from the conversation object. ([app/chat/[id]/layout.tsxL23-R21](diffhunk://#diff-d89d93bab6f3c4bde199788a425f5f20a1fad667ddac10f6119fb0a1cb7bf211L23-R21))
* `app/chat/[id]/layout.tsx`: Simplified the `withCheckPermission` logic by directly returning the result of `withFGA` and adjusting the unauthorized handling. ([app/chat/[id]/layout.tsxL51-R69](diffhunk://#diff-d89d93bab6f3c4bde199788a425f5f20a1fad667ddac10f6119fb0a1cb7bf211L51-R69))