### PR TITLE
Disable guardian enrollment on mobile

### DIFF
--- a/llm/components/conditional-purchase.tsx
+++ b/llm/components/conditional-purchase.tsx
@@ -2,6 +2,7 @@
 
 import { format, formatRelative } from "date-fns";
 import { useCallback, useEffect, useState } from "react";
+import { BrowserView, MobileView } from "react-device-detect";
 
 import { CancelRedIcon, CheckGreenIcon, TaskIcon } from "@/components/icons";
 import Loader from "@/components/loader";
@@ -51,23 +52,42 @@ export function ConditionalPurchase({ id, isMFAEnrolled }: { id: string; isMFAEn
 
   if (!isEnrolled) {
     return (
-      <div className="border border-gray-300 rounded-xl items-center w-full justify-between p-4 sm:p-6 flex flex-col sm:flex-row gap-4 sm:gap-0">
-        <div className="flex flex-col gap-1 sm:gap-1.5">
-          <h2 className="text-sm sm:text-base leading-6 font-semibold">Action Required: Setup Async Authentication</h2>
-          <p className="text-xs sm:text-sm leading-5 font-light text-gray-500">
-            Please enroll to Auth0 Guardian so we can notify you when the condition is met. This is necessary to secure
-            your future transaction.
-          </p>
-        </div>
-        <div className="w-full sm:w-fit">
-          <a
-            href={`/api/auth/login?returnTo=${window.location.pathname}&screenHint=mfa`}
-            className="w-full sm:w-fit inline-block text-center bg-gray-200 text-black whitespace-nowrap rounded-md text-sm font-normal transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 hover:bg-primary/90 hover:text-white py-2 px-4"
-          >
-            Enroll
-          </a>
-        </div>
-      </div>
+      <>
+        <MobileView>
+          <div className="border border-gray-300 rounded-xl items-center w-full justify-between p-4 sm:p-6 flex flex-col sm:flex-row gap-4 sm:gap-0">
+            <div className="flex flex-col gap-1 sm:gap-1.5">
+              <p className="text-xs sm:text-sm leading-5 font-light text-gray-500">
+                It looks like you&apos;re using a <strong>mobile device</strong>. This demo requires enrollment, which
+                involves scanning a QR code.
+              </p>
+              <p className="text-xs sm:text-sm leading-5 font-bold text-gray-500">
+                To try this feature, please open the demo on a computer.
+              </p>
+            </div>
+          </div>
+        </MobileView>
+        <BrowserView>
+          <div className="border border-gray-300 rounded-xl items-center w-full justify-between p-4 sm:p-6 flex flex-col sm:flex-row gap-4 sm:gap-0">
+            <div className="flex flex-col gap-1 sm:gap-1.5">
+              <h2 className="text-sm sm:text-base leading-6 font-semibold">
+                Action Required: Setup Async Authentication
+              </h2>
+              <p className="text-xs sm:text-sm leading-5 font-light text-gray-500">
+                Please enroll to Auth0 Guardian so we can notify you when the condition is met. This is necessary to
+                secure your future transaction.
+              </p>
+            </div>
+            <div className="w-full sm:w-fit">
+              <a
+                href={`/api/auth/login?returnTo=${window.location.pathname}&screenHint=mfa`}
+                className="w-full sm:w-fit inline-block text-center bg-gray-200 text-black whitespace-nowrap rounded-md text-sm font-normal transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 hover:bg-primary/90 hover:text-white py-2 px-4"
+              >
+                Enroll
+              </a>
+            </div>
+          </div>
+        </BrowserView>
+      </>
     );
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "pg": "^8.12.0",
         "postgres": "^3.4.4",
         "react": "^18",
+        "react-device-detect": "^2.2.3",
         "react-dom": "^18",
         "react-hook-form": "^7.53.0",
         "react-markdown": "^9.0.1",
@@ -11273,6 +11274,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-device-detect": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.3.tgz",
+      "integrity": "sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==",
+      "license": "MIT",
+      "dependencies": {
+        "ua-parser-js": "^1.0.33"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0",
+        "react-dom": ">= 0.14.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -12678,6 +12692,32 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.39.tgz",
+      "integrity": "sha512-k24RCVWlEcjkdOxYmVJgeD/0a1TiSpqLg+ZalVGV9lsnr4yqu0w7tX/x2xX6G4zpkgQnRf89lxuZ1wsbjXM8lw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "pg": "^8.12.0",
     "postgres": "^3.4.4",
     "react": "^18",
+    "react-device-detect": "^2.2.3",
     "react-dom": "^18",
     "react-hook-form": "^7.53.0",
     "react-markdown": "^9.0.1",


### PR DESCRIPTION
For push notifications Guardian only support enrolling with QR code currently.

This change prevent the user from starting the enrollment from a mobile device.