### PR TITLE
More style fixes for the chat on read-only mode

### DIFF
--- a/app/chat/[id]/layout.tsx
+++ b/app/chat/[id]/layout.tsx
@@ -28,14 +28,16 @@ async function RootLayout({ children, params }: RootChatParams) {
     <ChatProvider chatId={params.id} readOnly={!isOwner} hasMessages={messages.length > 0} ownerProfile={ownerProfile}>
       <div className="flex flex-col h-full w-full">
         <Header>
-          <ShareConversation>
-            {/**
-             * Because of a rendering bug with server components and client
-             * components, we require passing the chatId at this instance
-             * instead of using the chatId from the context.
-             */}
-            <ChatUsersPermissionsList chatId={params.id} />
-          </ShareConversation>
+          {isOwner && (
+            <ShareConversation>
+              {/**
+               * Because of a rendering bug with server components and client
+               * components, we require passing the chatId at this instance
+               * instead of using the chatId from the context.
+               */}
+              <ChatUsersPermissionsList chatId={params.id} />
+            </ShareConversation>
+          )}
         </Header>
 
         <AI initialAIState={messages} conversationID={params.id} readOnly={!isOwner}>

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -8,7 +8,7 @@ import { z } from "zod";
 
 import { useChat } from "@/components/chat/context";
 import { Examples } from "@/components/chat/examples";
-import { ArrowUpIcon, CircleIcon, Market0Icon } from "@/components/icons";
+import { ArrowUpIcon, CircleIcon, Market0Icon, SimplePlusIcon } from "@/components/icons";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem } from "@/components/ui/form";
@@ -143,7 +143,7 @@ export default function Chat({ params }: { params: { id: string } }) {
         </div>
 
         {!readOnly && (
-          <div className={cn("flex-shrink-1 min-w-0 min-h-0 bg-white max-w-4xl mx-auto w-full px-3 sm:px-1 h-fit")}>
+          <div className="flex-shrink-1 min-w-0 min-h-0 bg-white max-w-4xl mx-auto w-full px-3 sm:px-1 h-fit">
             <div className="p-3 bg-white border border-gray-200 rounded-lg focus-within:ring-stone-700 focus-within:ring-2 transition-all duration-150">
               <Form {...form}>
                 <form
@@ -210,19 +210,24 @@ export default function Chat({ params }: { params: { id: string } }) {
         )}
 
         {readOnly && (
-          <div className="flex-shrink-1 min-w-0 min-h-0 bg-white max-w-4xl mx-auto w-full px-3 sm:px-1 h-fit">
-            <div className="p-5 bg-gray-100  rounded-xl">
-              <div className="flex flex-row justify-between gap-2 items-center">
-                <div className="w-full space-y-0">
-                  <div className="bg-gray-100 shadow-none border-0 py-2 px-0 text-sm sm:text-base text-black">
-                    You have view-only access for this chat.
-                  </div>
-                </div>
-                <Link href="/">
-                  <Button className="py-6 px-8 m-0 text-md leading-6 font-light" variant="default" onClick={() => {}}>
-                    Start New Chat
-                  </Button>
-                </Link>
+          <div
+            className={cn(
+              "flex-shrink-1 min-w-0 min-h-0 bg-white max-w-4xl mx-auto w-full px-3 sm:px-1 h-fit",
+              "mb-5 text-sm sm:text-base"
+            )}
+          >
+            <div className="p-3 bg-gray-100 rounded-xl">
+              <div className="flex flex-row justify-between items-center gap-2 ">
+                <p className="w-full ps-3 text-slate-500">You have view-only access for this chat.</p>
+                <Button
+                  className="py-2 px-4 m-0 text-sm font-light flex gap-2"
+                  variant="default"
+                  onClick={() => {
+                    window.location.href = "/";
+                  }}
+                >
+                  <SimplePlusIcon /> Start New Chat
+                </Button>
               </div>
             </div>
           </div>

--- a/components/chat/navbar.tsx
+++ b/components/chat/navbar.tsx
@@ -70,10 +70,13 @@ function MenuMobile({ user, children }: { user: Claims; children?: React.ReactNo
                 <ArrowRightIcon />
               </Link>
             </li>
-            <li className="flex items-center py-3 px-5 border-t border-[#E2E8F0] justify-between">
-              <DrawerClose asChild>{children}</DrawerClose>
-              <ArrowRightIcon />
-            </li>
+            {children && (
+              <li className="flex items-center py-3 px-5 border-t border-[#E2E8F0] justify-between">
+                <DrawerClose asChild>{children}</DrawerClose>
+                <ArrowRightIcon />
+              </li>
+            )}
+
             <li className="border-t border-[#E2E8F0]">
               <Link
                 href="https://github.com/auth0-lab/market0"

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -131,6 +131,19 @@ function PlusIcon() {
   );
 }
 
+function SimplePlusIcon() {
+  return (
+    <svg width="17" height="17" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M8.2795 8.267H8.65634V7.89015V3.35682C8.65634 3.2704 8.72641 3.20033 8.81283 3.20033C8.89925 3.20033 8.96932 3.2704 8.96932 3.35682V7.89015V8.267H9.34616H13.8795C13.9659 8.267 14.036 8.33708 14.036 8.42349C14.036 8.50989 13.9659 8.57997 13.8795 8.57997H9.34616H8.96932V8.95682V13.4902C8.96932 13.5766 8.89923 13.6466 8.81283 13.6466C8.72643 13.6466 8.65634 13.5766 8.65634 13.4902V8.95682V8.57997H8.2795H3.74616C3.65974 8.57997 3.58968 8.50991 3.58968 8.42349C3.58968 8.33706 3.65974 8.267 3.74616 8.267H8.2795Z"
+        fill="#020617"
+        stroke="#F8FAFC"
+        strokeWidth="0.753695"
+      />
+    </svg>
+  );
+}
+
 function TrendingStocksIcon() {
   return (
     <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -866,6 +879,7 @@ export {
   IconAuth0,
   ExternalLink,
   PlusIcon,
+  SimplePlusIcon,
   TrendingStocksIcon,
   ArrowUpIcon,
   StockPriceIcon,


### PR DESCRIPTION
This pull request involves several updates to the chat application, mainly focusing on enhancing the user interface and improving the user experience. The most significant changes include adding conditional rendering for the chat sharing feature, updating the icon imports, and modifying the chat layout for both read-only and editable states.

### User Interface Enhancements:

* `app/chat/[id]/layout.tsx`: Added conditional rendering to the `ShareConversation` component, making it visible only for the chat owner. ([app/chat/[id]/layout.tsxR31](diffhunk://#diff-d89d93bab6f3c4bde199788a425f5f20a1fad667ddac10f6119fb0a1cb7bf211R31), [app/chat/[id]/layout.tsxR40](diffhunk://#diff-d89d93bab6f3c4bde199788a425f5f20a1fad667ddac10f6119fb0a1cb7bf211R40))
* `app/chat/[id]/page.tsx`: Updated the layout for both read-only and editable chat states to improve the user experience. The read-only state now includes a clearer message and a button to start a new chat. ([app/chat/[id]/page.tsxL146-R146](diffhunk://#diff-d3c52634ee721664b086ca6b33b4ce078faccdf0578b7f6455e8d74c23b68e3fL146-R146), [app/chat/[id]/page.tsxL213-L225](diffhunk://#diff-d3c52634ee721664b086ca6b33b4ce078faccdf0578b7f6455e8d74c23b68e3fL213-L225))

### Codebase Updates:

* [`components/icons.tsx`](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38R134-R146): Introduced a new `SimplePlusIcon` component and updated the icon exports to include it. [[1]](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38R134-R146) [[2]](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38R882)
* `app/chat/[id]/page.tsx`: Updated the icon imports to include the new `SimplePlusIcon`. ([app/chat/[id]/page.tsxL11-R11](diffhunk://#diff-d3c52634ee721664b086ca6b33b4ce078faccdf0578b7f6455e8d74c23b68e3fL11-R11))

### Additional Enhancements:

* [`components/chat/navbar.tsx`](diffhunk://#diff-15f493dff494e30100cf6856866ff634f02c6b8afd208d86646b70af643c9f8dR73-R79): Added conditional rendering for the `children` prop in the `MenuMobile` component to ensure it is displayed only when provided.This pull request includes several changes to the chat application, focusing on enhancing the user interface and improving the code structure. The most important changes include conditional rendering adjustments, new icon additions, and refactoring of existing components.

### Conditional Rendering Enhancements:
* `app/chat/[id]/layout.tsx`: Added conditional rendering for the `ShareConversation` component based on the `isOwner` flag. ([app/chat/[id]/layout.tsxR31](diffhunk://#diff-d89d93bab6f3c4bde199788a425f5f20a1fad667ddac10f6119fb0a1cb7bf211R31), [app/chat/[id]/layout.tsxR40](diffhunk://#diff-d89d93bab6f3c4bde199788a425f5f20a1fad667ddac10f6119fb0a1cb7bf211R40))
* [`components/chat/navbar.tsx`](diffhunk://#diff-15f493dff494e30100cf6856866ff634f02c6b8afd208d86646b70af643c9f8dL73-R79): Added conditional rendering for a list item in the mobile menu based on the presence of `children`.

### UI and Icon Updates:
* `app/chat/[id]/page.tsx`: Replaced a class name string with a template string using `cn` for dynamic class names and added the `SimplePlusIcon` to the "Start New Chat" button. ([app/chat/[id]/page.tsxL146-R146](diffhunk://#diff-d3c52634ee721664b086ca6b33b4ce078faccdf0578b7f6455e8d74c23b68e3fL146-R146), [app/chat/[id]/page.tsxL213-L225](diffhunk://#diff-d3c52634ee721664b086ca6b33b4ce078faccdf0578b7f6455e8d74c23b68e3fL213-L225))
* [`components/icons.tsx`](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38R134-R146): Added a new `SimplePlusIcon` component and included it in the export list. [[1]](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38R134-R146) [[2]](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38R882)

### Import Adjustments:
* `app/chat/[id]/page.tsx`: Updated imports to include the newly added `SimplePlusIcon`. ([app/chat/[id]/page.tsxL11-R11](diffhunk://#diff-d3c52634ee721664b086ca6b33b4ce078faccdf0578b7f6455e8d74c23b68e3fL11-R11))- **Read-only mode style fixes**
- **Fix navbar mobile for share button broken on read-only mode**
