### PR TITLE
Fix link should point to auth0.ai

### DIFF
--- a/components/chat/navbar.tsx
+++ b/components/chat/navbar.tsx
@@ -58,7 +58,7 @@ function MenuMobile({ user, children }: { user: Claims; children?: React.ReactNo
           <ul>
             <li className="border-t border-[#E2E8F0]">
               <Link
-                href="https://auth0.com"
+                href="https://auth0.ai"
                 rel="noopener"
                 target="_blank"
                 className="flex items-center justify-between py-3 px-5"


### PR DESCRIPTION
This pull request includes a small change to the `components/chat/navbar.tsx` file. The change updates a URL in the `MenuMobile` function to point to a new domain.

* [`components/chat/navbar.tsx`](diffhunk://#diff-15f493dff494e30100cf6856866ff634f02c6b8afd208d86646b70af643c9f8dL61-R61): Updated the `href` attribute in the `Link` component from `https://auth0.com` to `https://auth0.ai`.