### PR TITLE
Fix icons

### DIFF
--- a/components/chat/share/user-permission-actions.tsx
+++ b/components/chat/share/user-permission-actions.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import {} from "lucide-react";
 import React from "react";
 
+import { CheckIcon, ChevronDownIcon, TrashIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -15,7 +15,6 @@ import { toast } from "@/components/ui/use-toast";
 import { ChatUser } from "@/lib/db/chat-users";
 import { cn } from "@/lib/utils";
 import { removeChatUser } from "@/sdk/fga/chats";
-import { CheckIcon, ChevronDownIcon, TrashIcon } from "@radix-ui/react-icons";
 
 export interface UserPermissionActionsProps {
   user: ChatUser;
@@ -47,7 +46,7 @@ export function UserPermissionActions({ user }: UserPermissionActionsProps) {
       {role === "viewer" && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="font-normal flex gap-2">
+            <Button variant="ghost" className="font-normal flex gap-2 items-center">
               <span className="text-gray-600 text-sm">{role}</span>
               <ChevronDownIcon />
             </Button>

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -525,6 +525,14 @@ function ChevronRightIcon() {
   );
 }
 
+function ChevronDownIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M4 6L8 10L12 6" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
 function ShareIcon() {
   return (
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -643,6 +651,20 @@ function CircleCheckBigIcon() {
     >
       <path d="M21.801 10A10 10 0 1 1 17 3.335" />
       <path d="m9 11 3 3L22 4" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M13.3333 4L5.99996 11.3333L2.66663 8"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </svg>
   );
 }
@@ -794,7 +816,7 @@ function LogoutIcon() {
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-      <path d="M23.5 16H13.5" stroke="#FF3642" strokeWidth="1.25" stroke-linecap="round" stroke-linejoin="round" />
+      <path d="M23.5 16H13.5" stroke="#FF3642" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }
@@ -861,6 +883,30 @@ function GoogleIcon() {
   );
 }
 
+function TrashIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M3 6H21" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
+      <path
+        d="M19 6V20C19 21 18 22 17 22H7C6 22 5 21 5 20V6"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M8 6V4C8 3 9 2 10 2H14C15 2 16 3 16 4V6"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M10 11V17" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M14 11V17" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
 export {
   GoogleIcon,
   LogoutIcon,
@@ -875,6 +921,7 @@ export {
   EarningsIcon,
   CartIcon,
   ChevronRightIcon,
+  ChevronDownIcon,
   ArrowRightIcon,
   IconAuth0,
   ExternalLink,
@@ -898,6 +945,8 @@ export {
   LinkIcon2,
   CaretDownIcon,
   CircleCheckBigIcon,
+  CheckIcon,
   DiscordIcon,
   WarningPageIcon,
+  TrashIcon,
 };


### PR DESCRIPTION
This pull request includes changes to the `components/chat/share/user-permission-actions.tsx` and `components/icons.tsx` files to improve the user interface and code maintainability. The most important changes include replacing icon imports, adding new icon components, and fixing a typo in an SVG attribute.

### Icon Management:

* Replaced the `CheckIcon`, `ChevronDownIcon`, and `TrashIcon` imports from `@radix-ui/react-icons` with local imports from `@/components/icons`. (`components/chat/share/user-permission-actions.tsx`, [components/chat/share/user-permission-actions.tsxL18](diffhunk://#diff-4c71696d30c717e442320a14820363538036e72a387bd32060e4b9d6c410867cL18))
* Added new icon components: `ChevronDownIcon`, `CheckIcon`, and `TrashIcon` to `components/icons.tsx`. (`components/icons.tsx`, [[1]](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38R528-R535) [[2]](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38R658-R671) [[3]](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38R886-R909)
* Exported the newly added icons from `components/icons.tsx`. (`components/icons.tsx`, [[1]](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38R924) [[2]](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38R948-R951)

### UI Enhancement:

* Updated the `Button` component in `UserPermissionActions` to include `items-center` class for better alignment. (`components/chat/share/user-permission-actions.tsx`, [components/chat/share/user-permission-actions.tsxL50-R49](diffhunk://#diff-4c71696d30c717e442320a14820363538036e72a387bd32060e4b9d6c410867cL50-R49))

### Bug Fix:

* Fixed a typo in the `LogoutIcon` component's SVG attribute from `stroke-linecap` to `strokeLinecap`. (`components/icons.tsx`, [components/icons.tsxL797-R819](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38L797-R819))