### PR TITLE
adding envvar for gconn

### DIFF
--- a/components/auth0/user-profile.tsx
+++ b/components/auth0/user-profile.tsx
@@ -7,6 +7,7 @@ import { twMerge } from "tailwind-merge";
 import { buttonVariants } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import useConnectedAccounts from "@/hooks/auth0/use-connected-accounts";
+import { getGoogleConnectionName } from "@/lib/utils";
 
 import BasicInfoForm from "./basic-info-form";
 import ConnectedAccounts from "./connected-accounts";
@@ -76,7 +77,7 @@ export default function UserProfile({ user }: { user: KeyValueMap }) {
               <ConnectedAccounts
                 availableAccounts={[
                   {
-                    connection: "google-oauth2",
+                    connection: getGoogleConnectionName(),
                     displayName: "Google",
                     api: "google-all",
                     description: "Create and manage events in your Google Calendar.",

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -11,8 +11,10 @@ export const formatNumber = (value: number) =>
     currency: "USD",
   }).format(value);
 
-export const runAsyncFnWithoutBlocking = (
-  fn: (...args: any) => Promise<any>
-) => {
+export const runAsyncFnWithoutBlocking = (fn: (...args: any) => Promise<any>) => {
   fn();
 };
+
+export function getGoogleConnectionName() {
+  return process.env.NEXT_PUBLIC_GOOGLE_CONNECTION_NAME || "google-oauth2";
+}

--- a/sdk/auth0/3rd-party-apis/index.tsx
+++ b/sdk/auth0/3rd-party-apis/index.tsx
@@ -1,3 +1,4 @@
+import { getGoogleConnectionName } from "@/lib/utils";
 import { getSession } from "@auth0/nextjs-auth0";
 
 import * as box from "./providers/box";
@@ -12,9 +13,7 @@ const PROVIDERS_APIS = [
   {
     name: "google",
     api: "google-all",
-    requiredScopes: [
-      "https://www.googleapis.com/auth/calendar.events",
-    ],
+    requiredScopes: ["https://www.googleapis.com/auth/calendar.events"],
   },
   {
     name: "box",
@@ -54,10 +53,7 @@ const providerMapper = {
 
     const accessToken = await google.getAccessToken();
     if (accessToken) {
-      provider.containsRequiredScopes = await google.verifyAccessToken(
-        accessToken,
-        requiredScopes
-      );
+      provider.containsRequiredScopes = await google.verifyAccessToken(accessToken, requiredScopes);
     }
 
     provider.isAPIAccessEnabled = !!accessToken;
@@ -92,9 +88,7 @@ export async function getThirdPartyContext(params: With3PartyApisParams) {
   };
 
   for (const provider of params.providers) {
-    context[provider.name] = await providerMapper[provider.name](
-      provider.requiredScopes
-    );
+    context[provider.name] = await providerMapper[provider.name](provider.requiredScopes);
   }
 
   return context;
@@ -105,15 +99,12 @@ export async function handle3rdPartyParams(thirdPartyApi: string) {
   const user = session?.user;
   let authorizationParams = {};
 
-  const provider = PROVIDERS_APIS.find(
-    (provider) =>
-      provider.api === thirdPartyApi || provider.name === thirdPartyApi
-  );
+  const provider = PROVIDERS_APIS.find((provider) => provider.api === thirdPartyApi || provider.name === thirdPartyApi);
 
   switch (provider?.name) {
     case "google":
       authorizationParams = {
-        connection: "google-oauth2",
+        connection: getGoogleConnectionName(),
         connection_scope: provider?.requiredScopes.join(),
         access_type: "offline",
         login_hint: user?.email,

--- a/sdk/components/connect-google-account.tsx
+++ b/sdk/components/connect-google-account.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getGoogleConnectionName } from "@/lib/utils";
 import { PromptUserContainer } from "@/llm/components/prompt-user-container";
 
 export const ConnectGoogleAccount = ({
@@ -14,16 +15,20 @@ export const ConnectGoogleAccount = ({
   readOnly?: boolean;
 }) => {
   return (
-    <PromptUserContainer
-      title={title}
-      description={description}
-      action={{
-        label: "Connect",
-        onClick: () => {
-          window.location.href = `/api/auth/login?3rdPartyApi=${api}&linkWith=google-oauth2&returnTo=${window.location.pathname}`;
-        },
-      }}
-      readOnly={readOnly}
-    />
+    <>
+      <PromptUserContainer
+        title={title}
+        description={description}
+        action={{
+          label: "Connect",
+          onClick: () => {
+            window.location.href = `/api/auth/login?3rdPartyApi=${api}&linkWith=${getGoogleConnectionName()}&returnTo=${
+              window.location.pathname
+            }`;
+          },
+        }}
+        readOnly={readOnly}
+      />
+    </>
   );
 };


### PR DESCRIPTION
This pull request includes several changes to improve the handling of Google connection names dynamically and refactors some existing code for better readability. The most important changes include the introduction of the `getGoogleConnectionName` function, updates to the `UserProfile` and `ConnectGoogleAccount` components, and refactoring in the `3rd-party-apis` module.

### Dynamic Google Connection Name Handling:

* [`lib/utils.ts`](diffhunk://#diff-98e56006aa8453a29bc2b8bc8e6f718b3f17ba66470f3a52a5dc5bd643482e70L14-R20): Added the `getGoogleConnectionName` function to dynamically retrieve the Google connection name from environment variables.
* [`components/auth0/user-profile.tsx`](diffhunk://#diff-de5f50610000edf95743f2e5b8dda5c2b170992b03a44211305705b2e9b2d2eaR10): Updated the `UserProfile` component to use the new `getGoogleConnectionName` function for the Google connection name. [[1]](diffhunk://#diff-de5f50610000edf95743f2e5b8dda5c2b170992b03a44211305705b2e9b2d2eaR10) [[2]](diffhunk://#diff-de5f50610000edf95743f2e5b8dda5c2b170992b03a44211305705b2e9b2d2eaL79-R80)
* [`sdk/components/connect-google-account.tsx`](diffhunk://#diff-ff792abf7e0b8fde34c11bc893ef4bd00138ceaebe7abdf77bc7834790c1f313R3): Updated the `ConnectGoogleAccount` component to use the new `getGoogleConnectionName` function for the Google connection name. [[1]](diffhunk://#diff-ff792abf7e0b8fde34c11bc893ef4bd00138ceaebe7abdf77bc7834790c1f313R3) [[2]](diffhunk://#diff-ff792abf7e0b8fde34c11bc893ef4bd00138ceaebe7abdf77bc7834790c1f313R18-R32)

### Code Refactoring:

* [`sdk/auth0/3rd-party-apis/index.tsx`](diffhunk://#diff-8151a8ad79215b5ce8adc926365baa8ffb7130e6747651e87e48fe96e1466327R1): Refactored multiple instances of code to improve readability and maintainability, including using the `getGoogleConnectionName` function and simplifying array and object manipulations. [[1]](diffhunk://#diff-8151a8ad79215b5ce8adc926365baa8ffb7130e6747651e87e48fe96e1466327R1) [[2]](diffhunk://#diff-8151a8ad79215b5ce8adc926365baa8ffb7130e6747651e87e48fe96e1466327L15-R16) [[3]](diffhunk://#diff-8151a8ad79215b5ce8adc926365baa8ffb7130e6747651e87e48fe96e1466327L57-R56) [[4]](diffhunk://#diff-8151a8ad79215b5ce8adc926365baa8ffb7130e6747651e87e48fe96e1466327L95-R91) [[5]](diffhunk://#diff-8151a8ad79215b5ce8adc926365baa8ffb7130e6747651e87e48fe96e1466327L108-R107)