### PR TITLE
Fix share button styles

### DIFF
--- a/components/chat/navbar.tsx
+++ b/components/chat/navbar.tsx
@@ -70,12 +70,7 @@ function MenuMobile({ user, children }: { user: Claims; children?: React.ReactNo
                 <ArrowRightIcon />
               </Link>
             </li>
-            {children && (
-              <li className="flex items-center py-3 px-5 border-t border-[#E2E8F0] justify-between">
-                <DrawerClose asChild>{children}</DrawerClose>
-                <ArrowRightIcon />
-              </li>
-            )}
+            {children && <li className="border-t border-[#E2E8F0]">{children}</li>}
 
             <li className="border-t border-[#E2E8F0]">
               <Link

--- a/components/chat/share.tsx
+++ b/components/chat/share.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 import { addChatUsers } from "@/sdk/fga/chats";
 import { zodResolver } from "@hookform/resolvers/zod";
 
-import { CircleCheckBigIcon, LinkIcon2, ShareIcon, ShareMenuIcon } from "../icons";
+import { ArrowRightIcon, CircleCheckBigIcon, LinkIcon2, ShareIcon, ShareMenuIcon } from "../icons";
 import Loader from "../loader";
 import { Button, ButtonProps } from "../ui/button";
 import {
@@ -38,30 +38,44 @@ const formSchema = z.object({
   role: z.enum(["Viewer", "Editor"]),
 });
 
-const ShareButton = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+const ShareButton = React.forwardRef<HTMLButtonElement & HTMLAnchorElement, ButtonProps>((props, ref) => {
   const { disabled, className, ...rest } = props;
   return (
-    <>
-      <Button
-        ref={ref}
-        className={cn(
-          "sm:bg-gray-100 text-slate-800 sm:gap-2 items-center sm:px-3 sm:py-2 rounded-md shadow-none hover:ring-2 ring-[#CFD1D4] border-gray-100 text-sm hover:bg-gray-100 hover:text-black transition-all duration-300",
-          { "disabled opacity-50 cursor-not-allowed": disabled },
+    <Button
+      ref={ref}
+      className={cn(
+        // common styles
+        "flex items-center text-slate-800 shadow-none font-normal bg-transparent hover:bg-transparent h-full w-full",
+        // button navbar styles (desktop)
+        "sm:text-sm sm:bg-gray-100 sm:hover:bg-gray-100 sm:border-gray-100 sm:ring-[#CFD1D4] sm:hover:ring-2 sm:rounded-md hover:text-black sm:transition-all sm:duration-300",
+        "sm:justify-center sm:px-3 sm:py-2 ",
+        // collapsible navbar link styles (mobile)
+        "justify-between px-5 py-3",
+        // disabled styles
+        { "disabled opacity-50 cursor-not-allowed": disabled },
+        // additional styles provided by user
+        className
+      )}
+      {...rest}
+    >
+      {/** As button (desktop) */}
 
-          "flex items-center gap-4 px-0 font-normal bg-transparent shadow-none",
-          className
-        )}
-        {...rest}
-      >
-        <span className="hidden sm:inline-flex">
-          <ShareIcon />
-        </span>
-        <span className="sm:hidden inline-flex">
-          <ShareMenuIcon />
-        </span>{" "}
+      <div className="hidden sm:flex items-center gap-2">
+        <ShareIcon />
         Share chat
-      </Button>
-    </>
+      </div>
+
+      {/** As collapsible navbar link (mobile) */}
+
+      <div className="flex sm:hidden items-center gap-4">
+        <ShareMenuIcon />
+        Share Chat
+      </div>
+
+      <span className="inline-flex sm:hidden">
+        <ArrowRightIcon />
+      </span>
+    </Button>
   );
 });
 


### PR DESCRIPTION
This pull request includes several changes to the `components/chat` directory, focusing mainly on simplifying the code and improving the user interface. The most important changes include modifying the `MenuMobile` component to simplify child rendering, updating the `ShareButton` component to handle both button and link elements, and adding new icon imports.

### Code Simplification and UI Improvement:

* [`components/chat/navbar.tsx`](diffhunk://#diff-15f493dff494e30100cf6856866ff634f02c6b8afd208d86646b70af643c9f8dL73-R73): Simplified the rendering of children in the `MenuMobile` component by removing unnecessary elements and directly rendering children within a list item.

* [`components/chat/share.tsx`](diffhunk://#diff-8ed906ceef2d5798159c59dbb946bd52c7e62b2186177dc867a8f807f614428bL41-L64): Updated the `ShareButton` component to handle both `HTMLButtonElement` and `HTMLAnchorElement` types, and refactored the styles to be more modular and clear.

### Icon Management:

* [`components/chat/share.tsx`](diffhunk://#diff-8ed906ceef2d5798159c59dbb946bd52c7e62b2186177dc867a8f807f614428bL13-R13): Added `ArrowRightIcon` to the list of imported icons to support the updated `ShareButton` component.