### PR TITLE
Fix share icon

### DIFF
--- a/components/chat/share.tsx
+++ b/components/chat/share.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils";
 import { addChatUsers } from "@/sdk/fga/chats";
 import { zodResolver } from "@hookform/resolvers/zod";
 
-import { ArrowRightIcon, CircleCheckBigIcon, LinkIcon2, ShareIcon, ShareMenuIcon } from "../icons";
+import { ArrowRightIcon, CircleCheckBigIcon, LinkIcon2, Share2Icon, ShareMenuIcon } from "../icons";
 import Loader from "../loader";
 import { Button, ButtonProps } from "../ui/button";
 import {
@@ -61,7 +61,7 @@ const ShareButton = React.forwardRef<HTMLButtonElement & HTMLAnchorElement, Butt
       {/** As button (desktop) */}
 
       <div className="hidden sm:flex items-center gap-2">
-        <ShareIcon />
+        <Share2Icon className="h-3.5 w-3.5" />
         Share chat
       </div>
 

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -555,6 +555,56 @@ function ShareIcon() {
   );
 }
 
+function Share2Icon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      {...props}
+    >
+      <path
+        d="M18 8C19.6569 8 21 6.65685 21 5C21 3.34315 19.6569 2 18 2C16.3431 2 15 3.34315 15 5C15 6.65685 16.3431 8 18 8Z"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6 15C7.65685 15 9 13.6569 9 12C9 10.3431 7.65685 9 6 9C4.34315 9 3 10.3431 3 12C3 13.6569 4.34315 15 6 15Z"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M18 22C19.6569 22 21 20.6569 21 19C21 17.3431 19.6569 16 18 16C16.3431 16 15 17.3431 15 19C15 20.6569 16.3431 22 18 22Z"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M8.59003 13.51L15.42 17.49"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M15.41 6.51L8.59003 10.49"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 function CartIcon() {
   return (
     <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -715,9 +765,17 @@ function LearnMenuIcon() {
   );
 }
 
-function ShareMenuIcon() {
+function ShareMenuIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
   return (
-    <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      width="32"
+      height="32"
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      {...props}
+    >
       <rect width="32" height="32" rx="4" fill="#F1F5F9" />
       <path
         d="M21 12.666C22.3807 12.666 23.5 11.5467 23.5 10.166C23.5 8.7853 22.3807 7.66602 21 7.66602C19.6193 7.66602 18.5 8.7853 18.5 10.166C18.5 11.5467 19.6193 12.666 21 12.666Z"
@@ -968,6 +1026,7 @@ export {
   Market0Icon,
   CircleIcon,
   ShareIcon,
+  Share2Icon,
   LinkIcon,
   LinkIcon2,
   CaretDownIcon,


### PR DESCRIPTION
This pull request includes changes to the `components/chat/share.tsx` and `components/icons.tsx` files to replace the `ShareIcon` with a new `Share2Icon`. It also updates the `ShareMenuIcon` to accept additional props and class names.

Icon updates:

* [`components/chat/share.tsx`](diffhunk://#diff-8ed906ceef2d5798159c59dbb946bd52c7e62b2186177dc867a8f807f614428bL13-R13): Replaced `ShareIcon` with `Share2Icon` in the imports and in the `ShareButton` component. [[1]](diffhunk://#diff-8ed906ceef2d5798159c59dbb946bd52c7e62b2186177dc867a8f807f614428bL13-R13) [[2]](diffhunk://#diff-8ed906ceef2d5798159c59dbb946bd52c7e62b2186177dc867a8f807f614428bL64-R64)
* [`components/icons.tsx`](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38R558-R607): Added a new `Share2Icon` component with SVG properties and paths.
* [`components/icons.tsx`](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38L718-R778): Modified `ShareMenuIcon` to accept `className` and other props.
* [`components/icons.tsx`](diffhunk://#diff-4f7e327dc55b1525401c7f5d360443fbc1edc184ccdaaeefb18b894cf3982a38R1029): Exported the new `Share2Icon` component.