### PR TITLE
fix styles for conversation picker on mobile and desktop

### DIFF
--- a/components/chat/conversation-picker.tsx
+++ b/components/chat/conversation-picker.tsx
@@ -2,7 +2,6 @@
 import { useUIState } from "ai/rsc";
 import { formatDistance, formatRelative, startOfDay } from "date-fns";
 import { groupBy, isEqual } from "lodash-es";
-import Link from "next/link";
 import * as React from "react";
 
 import { Button, ButtonProps } from "@/components/ui/button";
@@ -44,9 +43,9 @@ const PickerButton = React.forwardRef<HTMLButtonElement, ButtonProps>(({ childre
       // common styles
       "inline-flex items-center justify-between overflow-hidden whitespace-nowrap truncate text-sm",
       // (desktop)
-      "sm:max-w-[320px]",
+      "sm:w-[320px]",
       // (mobile)
-      "w-full max-w-[240px]",
+      "w-[220px]",
       // additional styles provided by user
       className
     )}
@@ -111,7 +110,7 @@ export default function ConversationPicker({ selectedConversation: initialConver
       <PopoverTrigger asChild>
         <PickerButton>{getTitle(selectedConversation)}</PickerButton>
       </PopoverTrigger>
-      <PopoverContent className="w-[350px] p-0">
+      <PopoverContent className="w-[220px] sm:w-[320px] p-0" align="end">
         <Command>
           <CommandList>
             <CommandEmpty>No chats found.</CommandEmpty>
@@ -127,7 +126,7 @@ export default function ConversationPicker({ selectedConversation: initialConver
                     value={conversation.conversationID}
                   >
                     <a href={`/chat/${conversation.conversationID}`} className="flex w-full items-center">
-                      {getTitle(conversation)}
+                      <span className="truncate">{getTitle(conversation)}</span>
                       {selectedConversation.conversationID === conversation.conversationID && (
                         <CheckIcon className="ml-auto" />
                       )}


### PR DESCRIPTION
This pull request includes several changes to the `components/chat/conversation-picker.tsx` file, focusing primarily on UI adjustments and code cleanup. The most important changes include updating button width styles, modifying popover content width, and ensuring conversation titles are truncated properly.

UI Adjustments:

* Changed button width styles for both desktop and mobile views to fixed widths (`sm:w-[320px]` and `w-[220px]` respectively) to ensure consistent sizing. (`[components/chat/conversation-picker.tsxL47-R48](diffhunk://#diff-a19be5dbd083cbb8569c04543075e3e7eeab22d679dcb05501ad24aebd95700eL47-R48)`)
* Updated the popover content width to be responsive, setting it to `w-[220px]` for default and `sm:w-[320px]` for small screen sizes, and aligned it to the end. (`[components/chat/conversation-picker.tsxL114-R113](diffhunk://#diff-a19be5dbd083cbb8569c04543075e3e7eeab22d679dcb05501ad24aebd95700eL114-R113)`)

Code Cleanup:

* Removed the unused import of `Link` from `next/link` to clean up the code. (`[components/chat/conversation-picker.tsxL5](diffhunk://#diff-a19be5dbd083cbb8569c04543075e3e7eeab22d679dcb05501ad24aebd95700eL5)`)
* Wrapped conversation titles in a `span` with the `truncate` class to ensure long titles are properly truncated within their container. (`[components/chat/conversation-picker.tsxL130-R129](diffhunk://#diff-a19be5dbd083cbb8569c04543075e3e7eeab22d679dcb05501ad24aebd95700eL130-R129)`)