### PR TITLE
Refactor conversations

### DIFF
--- a/app/actions.tsx
+++ b/app/actions.tsx
@@ -30,7 +30,7 @@ export const AI = (p: Props) => {
       "use server";
       const user = await getUser();
       await conversations.save({
-        conversationID,
+        id: conversationID,
         messages: state,
         ownerID: user.sub,
       });

--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -1,10 +1,13 @@
 import { generateId } from "ai";
 import { redirect } from "next/navigation";
 
+import { conversations } from "@/lib/db";
+import { getUser } from "@/sdk/fga";
 import { assignChatOwner } from "@/sdk/fga/chats";
 
 export default async function Root() {
-  const conversationID = generateId();
+  const user = await getUser();
+  const conversationID = await conversations.create({ ownerID: user.sub });
   await assignChatOwner(conversationID);
   redirect(`/chat/${conversationID}`);
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,13 @@
-import { assignChatOwner } from "@/sdk/fga/chats";
 import { generateId } from "ai";
 import { redirect } from "next/navigation";
 
+import { conversations } from "@/lib/db";
+import { getUser } from "@/sdk/fga";
+import { assignChatOwner } from "@/sdk/fga/chats";
+
 export default async function Root() {
-  const conversationID = generateId();
+  const user = await getUser();
+  const conversationID = await conversations.create({ ownerID: user.sub });
   await assignChatOwner(conversationID);
   redirect(`/chat/${conversationID}`);
 }

--- a/components/chat/conversation-picker.tsx
+++ b/components/chat/conversation-picker.tsx
@@ -65,7 +65,7 @@ export default function ConversationPicker({ selectedConversation: initialConver
   const [selectedConversation, setSelectedConversation] = React.useState<ConversationData>(initialConversation);
 
   React.useEffect(() => {
-    const c = conversations.find((c) => c.conversationID === selectedConversation.conversationID);
+    const c = conversations.find((c) => c.id === selectedConversation.id);
     if (!c) {
       return;
     }
@@ -120,16 +120,10 @@ export default function ConversationPicker({ selectedConversation: initialConver
             {Object.entries(groups).map(([day, conversations]) => (
               <CommandGroup key={day} heading={day}>
                 {conversations.map((conversation) => (
-                  <CommandItem
-                    key={conversation.conversationID}
-                    className="text-sm"
-                    value={conversation.conversationID}
-                  >
-                    <a href={`/chat/${conversation.conversationID}`} className="flex w-full items-center">
+                  <CommandItem key={conversation.id} className="text-sm" value={conversation.id}>
+                    <a href={`/chat/${conversation.id}`} className="flex w-full items-center">
                       <span className="truncate">{getTitle(conversation)}</span>
-                      {selectedConversation.conversationID === conversation.conversationID && (
-                        <CheckIcon className="ml-auto" />
-                      )}
+                      {selectedConversation.id === conversation.id && <CheckIcon className="ml-auto" />}
                     </a>
                   </CommandItem>
                 ))}

--- a/database/market0/V016__refactor_chats.sql
+++ b/database/market0/V016__refactor_chats.sql
@@ -1,0 +1,23 @@
+-- Rename the table
+ALTER TABLE chat_histories RENAME TO conversations;
+
+-- Drop the unique index
+DROP INDEX IF EXISTS chat_histories_conversation_id_index;
+
+-- Drop the primary key constraint and the id column
+ALTER TABLE conversations
+  DROP CONSTRAINT chat_histories_pkey;
+
+ALTER TABLE conversations
+  DROP COLUMN id;
+
+-- Rename conversation_id to id
+ALTER TABLE conversations RENAME COLUMN conversation_id TO id;
+
+-- Rename user_id to owner_id
+ALTER TABLE conversations RENAME COLUMN user_id TO owner_id;
+
+-- Add the primary key on id only
+ALTER TABLE conversations
+  ADD PRIMARY KEY (id);
+

--- a/lib/db/sql.ts
+++ b/lib/db/sql.ts
@@ -2,6 +2,10 @@ import postgres from "postgres";
 
 import { neon } from "@neondatabase/serverless";
 
+const queryDebugger = (connection: number, query: string, parameters: any[], paramTypes: any[]) => {
+  console.log('postgres:', { connection, query, parameters, paramTypes });
+};
+
 export const sql: ReturnType<typeof postgres> = process.env.USE_NEON
   ? (neon(process.env.DATABASE_URL as string) as unknown as ReturnType<
     typeof postgres
@@ -9,5 +13,6 @@ export const sql: ReturnType<typeof postgres> = process.env.USE_NEON
   : postgres({
     connection: {
       TimeZone: process.env.PGTZ ?? "UTC",
-    }
+    },
+    debug: process.env.DEBUG_QUERIES ? queryDebugger : undefined,
   });

--- a/llm/actions/history.tsx
+++ b/llm/actions/history.tsx
@@ -3,17 +3,6 @@
 import { conversations } from "@/lib/db";
 import { getUser } from "@/sdk/fga";
 
-/**
- *
- * Return the history for a conversation from the store
- *
- * @param id
- * @returns
- */
-export const getHistoryFromStore = async (id: string) => {
-  return await conversations.get({ conversationID: id });
-};
-
 export const listUserConversations = async () => {
   const user = await getUser();
   return await conversations.list({ ownerID: user.sub });

--- a/llm/types.ts
+++ b/llm/types.ts
@@ -33,7 +33,7 @@ export interface ServerMessage {
 }
 
 export interface Conversation {
-  conversationID: string;
+  id: string;
   messages: ServerMessage[];
   ownerID: string;
   title: string;


### PR DESCRIPTION
- Rename table chat_histories to conversations
- Drop autonumeric primary key `id`
- Rename `conversation_id` to `id`
- Now the conversation_id will be the primary key, it has to be unique
- Rename `conversations.user_id` to `conversations.owner_id`
- A conversation will be created even if empty previous to the redirect. To ensure is owned by the user and the id is unique.

This is to avoid the user to be redirected to a non-existing conversation.

Before the share conversation feature the conversation id was tied to the user_id. ie: two users could have the same conversation_id. This was not considered since in FGA the conversation_id is unique.