### PR TITLE
fix: update conversation messages and isPublic flag

### DIFF
--- a/lib/db/conversations.ts
+++ b/lib/db/conversations.ts
@@ -120,27 +120,28 @@ export const save = async ({ id, ownerID, messages, isPublic }:
 ): Promise<void> => {
   if (messages !== undefined) {
     const formattedMessages = process.env.USE_NEON ? JSON.stringify(messages) : (messages as any);
-    const { count } = await sql`
+    const updated = await sql`
       UPDATE conversations
       SET updated_at = NOW(),
         messages = ${formattedMessages}::json
       WHERE id = ${id} AND owner_id = ${ownerID}
-      RETURNING *
+      RETURNING id
     `;
-    if (!count) {
+    if (!updated[0]) {
       throw new Error('Conversation does not exists.');
     }
     await summarizeConversation(id, messages);
   }
 
   if (isPublic !== undefined) {
-    const { count } = await sql`
+    const updated = await sql`
       UPDATE conversations
       SET is_public = ${isPublic},
         updated_at = NOW()
       WHERE id = ${id} AND owner_id = ${ownerID}
+      RETURNING id
     `;
-    if (!count) {
+    if (!updated[0]) {
       throw new Error('Conversation does not exists.');
     }
   }


### PR DESCRIPTION
This commit fixes an issue with updating conversation messages and the isPublic flag in the conversations module. The code now properly updates the messages and isPublic flag in the conversations table based on the provided parameters. Additionally, the commit includes error handling for cases where the conversation does not exist.