### PR TITLE
fix connection name on requested_token_type

### DIFF
--- a/sdk/auth0/3rd-party-apis/providers/google.ts
+++ b/sdk/auth0/3rd-party-apis/providers/google.ts
@@ -3,6 +3,10 @@
 import { getSession } from "@auth0/nextjs-auth0";
 
 const fetchAccessToken = async (auth0IdToken: string): Promise<string> => {
+  const connectionName = process.env.NEXT_PUBLIC_GOOGLE_CONNECTION_NAME;
+  const requestedTokenTypeBase = "http://auth0.com/oauth/token-type/social-access-token/google-oauth2";
+  const requested_token_type = connectionName ? `${requestedTokenTypeBase}/${connectionName}` : requestedTokenTypeBase;
+
   const res = await fetch(`${process.env.AUTH0_ISSUER_BASE_URL}/oauth/token`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -12,7 +16,7 @@ const fetchAccessToken = async (auth0IdToken: string): Promise<string> => {
       client_secret: process.env.AUTH0_CLIENT_SECRET,
       subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
       subject_token: auth0IdToken,
-      requested_token_type: "http://auth0.com/oauth/token-type/social-access-token/google-oauth2",
+      requested_token_type,
     }),
   });
 


### PR DESCRIPTION
This pull request includes updates to the `fetchAccessToken` function in the `sdk/auth0/3rd-party-apis/providers/google.ts` file to dynamically set the `requested_token_type` based on the environment configuration.

Enhancements to token fetching:

* [`sdk/auth0/3rd-party-apis/providers/google.ts`](diffhunk://#diff-f024099c7d8759c8ff84cf46af806de351214cc6d8ff1173592e5e060f3f75dfR6-R9): Added logic to dynamically set the `requested_token_type` based on the `NEXT_PUBLIC_GOOGLE_CONNECTION_NAME` environment variable. This allows for more flexible configuration of the token type. [[1]](diffhunk://#diff-f024099c7d8759c8ff84cf46af806de351214cc6d8ff1173592e5e060f3f75dfR6-R9) [[2]](diffhunk://#diff-f024099c7d8759c8ff84cf46af806de351214cc6d8ff1173592e5e060f3f75dfL15-R19)