### PR TITLE
updating default actions

### DIFF
--- a/components/chat/conversation.tsx
+++ b/components/chat/conversation.tsx
@@ -74,7 +74,7 @@ export default function Conversation() {
         ref={scrollRef}
         className="flex flex-col flex-no-wrap h-full overflow-y-auto overscroll-y-none gap-2 sm:gap-3 w-full pt-11 transition-all duration-300"
       >
-        <div className="flex-1 overflow-y-auto px-9">
+        <div className="flex-1 overflow-y-auto px-0 sm:px-9">
           <div
             id="conversation"
             ref={messagesRef}

--- a/lib/examples.tsx
+++ b/lib/examples.tsx
@@ -23,8 +23,8 @@ export const examples = [
   },
   {
     id: generateId(),
-    title: "Buy ZEKO if P/E ratio is above 0",
-    message: "Buy 10 ZEKO when P/E ratio is above 0",
+    title: "Buy ZEKO if P/E ratio is above 15",
+    message: "Buy 10 ZEKO when P/E ratio is above 15",
   },
 ];
 
@@ -56,7 +56,7 @@ export const menuItems = [
   },
   {
     id: generateId(),
-    message: "Buy 10 ZEKO when P/E ratio is above 0",
+    message: "Buy 10 ZEKO when P/E ratio is above 15",
     icon: <CartIcon />,
   },
 ];

--- a/llm/components/stocks/conditional-purchase.mdx
+++ b/llm/components/stocks/conditional-purchase.mdx
@@ -1,10 +1,10 @@
-## **Explained Prompt**: Buy ZEKO if P/E ratio is above 0
+## **Explained Prompt**: Buy ZEKO if P/E ratio is above 15
 
 <UseCase type="async-human" />
 
 ### Scenario
 
-When the user requests to buy a specific company stock when its P/E ratio is above 0, the chatbot will monitor this metric and seek the user's approval (authorization) before executing any transaction.
+When the user requests to buy a specific company stock when its P/E ratio is above 15, the chatbot will monitor this metric and seek the user's approval (authorization) before executing any transaction.
 
 <br />
 This process is streamlined through Auth0, utilizing the CIBA (client-initiated backchannel authentication) flow to facilitate


### PR DESCRIPTION
This pull request includes changes to the `components/chat/conversation.tsx`, `lib/examples.tsx`, and `llm/components/stocks/conditional-purchase.mdx` files. The primary focus is on adjusting the padding in the chat component and updating the P/E ratio threshold in multiple instances.

Styling adjustments:

* [`components/chat/conversation.tsx`](diffhunk://#diff-935dce1dfa94511d5289615e92721fa4752f15d6d06c73b2eddd18a19166ae1aL77-R77): Adjusted the padding for the chat container to have no padding on smaller screens and retain the original padding on larger screens.

Updates to P/E ratio threshold:

* [`lib/examples.tsx`](diffhunk://#diff-67a7b4a1cbdce6ce143beaa6f08f150bacce59759c3665e16fd8cc834138dfb8L26-R27): Updated the P/E ratio threshold from 0 to 15 in the example title and message.
* [`lib/examples.tsx`](diffhunk://#diff-67a7b4a1cbdce6ce143beaa6f08f150bacce59759c3665e16fd8cc834138dfb8L59-R59): Updated the P/E ratio threshold from 0 to 15 in the menu item message.
* [`llm/components/stocks/conditional-purchase.mdx`](diffhunk://#diff-7de11fdff8c4891fddd26f5ccde0c0af6e8bdb1e0cc92ebf0154c14332fd6fceL1-R7): Updated the P/E ratio threshold from 0 to 15 in the explained prompt and scenario description.