### PR TITLE
Fix product name in text

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This is a demo of an interactive financial assistant. It can show you stocks, te
 ### Prerequisites
 
 - An Auth0 Lab account, you can create one [here](https://manage.auth0lab.com/).
-- An OKTA FGA account, you can create one [here](https://dashboard.fga.dev).
+- An Okta FGA account, you can create one [here](https://dashboard.fga.dev).
 - An OpenAI account and API key create one [here](https://platform.openai.com).
 - Docker to run the postgresql container.
 
 ### FGA Configuration
 
-To setup OKTA FGA for the sample, create a client with the following permissions:
+To setup Okta FGA for the sample, create a client with the following permissions:
 
 - `Read/Write model, changes, and assertions`
 - `Write and delete tuples`

--- a/llm/components/forecasts/documents.mdx
+++ b/llm/components/forecasts/documents.mdx
@@ -7,7 +7,7 @@
 When a user submits a forecast inquiry for a specific company, like Zeko, the chatbot will generate a response using relevant documents retrieved from the vector store. By default, Market0 will only include publicly available filings. However, users may also have access to analyst-level forecasts, providing them with additional insights when the response is generated.
 
 <br />
-OKTA FGA (Fine-Grained Authorization) is used to check which documents the user has access to based on their permissions.
+Okta Fine Grained Authorization (FGA) is used to check which documents the user has access to based on their permissions.
 
 ### How it works
 

--- a/llm/tools/forecasts/get-forecasts.tsx
+++ b/llm/tools/forecasts/get-forecasts.tsx
@@ -14,7 +14,7 @@ import { getUser } from "@/sdk/fga";
 
 /**
  * This is an example tool that uses Retrieval Augmented Generation (RAG) to generate a response.
- * As part of the retrievel process, the tool checks in OKTA FGA if the user has access to the matching document.
+ * As part of the retrievel process, the tool checks in Okta FGA if the user has access to the matching document.
  */
 export default defineTool("get_forecasts", () => {
   const history = getHistory();


### PR DESCRIPTION
- Improve wording in the LLM example documentation from `OKTA FGA (Fine-Grained Authorization)` to `Okta Fine Grained Authorization (FGA)` to comply with product name.
- Fixes textual instances where it was OKTA to Okta