### PR TITLE
Fix CIBA authentication with missing params

### DIFF
--- a/sdk/auth0/ciba.ts
+++ b/sdk/auth0/ciba.ts
@@ -30,6 +30,7 @@ const startAuthenticationRequest = async (
       client_id: process.env.AUTH0_CLIENT_ID!,
       client_secret: process.env.AUTH0_CLIENT_SECRET!,
       scope,
+      binding_message: "Buy 10 Zeko shares",
       login_hint: JSON.stringify({
         format: "iss_sub",
         iss: `${process.env.AUTH0_ISSUER_BASE_URL!}/`,


### PR DESCRIPTION
This pull request includes a minor change to the `sdk/auth0/ciba.ts` file. It adds a `binding_message` parameter to the `startAuthenticationRequest` function to prompt users with a specific authorization message during the authentication process.

* [`sdk/auth0/ciba.ts`](diffhunk://#diff-14a9b503760c8383b4e040debeb4b19fc4e317f60efcc4dfd33f58732524c5e6R33): Added a `binding_message` parameter to the `startAuthenticationRequest` function to include a user authorization prompt.