### PR TITLE
ci: add Snyk SCA dependency scan workflow (SEC-18849)

### DIFF
--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -1,0 +1,12 @@
+name: SCA
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  snyk-cli:
+    uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main
+    with:
+      node-version: "20"
+    secrets: inherit


### PR DESCRIPTION
## What

Adds `.github/workflows/sca_scan.yml`, a new GitHub Actions workflow that runs a **Snyk Open Source (SCA)** dependency scan on every push to `main`.

## Why

Resolves **SEC-18849** — Product Security requires the Snyk SCA scanner to be wired into the build of `auth0-lab/market0`, running on the default branch so their automation can detect coverage and track third-party dependency vulnerabilities.

## Approach

Per the [Dependency Scanning self-service wiki](https://oktainc.atlassian.net/wiki/spaces/REX/pages/656874051/Dependency+Scanning+-+Self-Service+Wiki), this uses **Scan Option 2 (Reusable Workflow)**, which is the recommended path because:

- The repo is **public**, so it calls the public `auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main` and runs on `main` only.
- There is **no existing build workflow** to attach an inline step to (Option 1), so the standalone reusable workflow is the correct fit.

```yaml
name: SCA

on:
  push:
    branches: ["main"]

jobs:
  snyk-cli:
    uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main
    with:
      node-version: "20"
    secrets: inherit
```

- `node-version: "20"` matches the project's runtime (Next.js 14.2, `@types/node: ^20`); the reusable workflow defaults to Node 16.
- `secrets: inherit` passes the org-managed `SNYK_TOKEN` / `SIGNAL_HANDLER_TOKEN` / `SIGNAL_HANDLER_DOMAIN` through to the reusable workflow.

## Note on execution

The scan triggers on **push to `main`**, so the first real scan runs **after this PR is merged** (the public-repo guidance is main-only, no PR trigger).

## Prerequisites (outside this PR)

For the scan to succeed, the repo must have, in Terminus:
- **Require Build Secrets Management** = `true`
- **CI system** = GitHub

These deliver the org/company-scoped Snyk secrets at runtime. If the scan can't find `SNYK_TOKEN`, ping **#rex-sca-integration**.

## Rollback

Single additive file. Revert this PR / delete the workflow — no impact on the app build, Vercel deploy, the existing `db.yml` migration workflow, or FOSSA.